### PR TITLE
Fix toString method for Room Model class

### DIFF
--- a/Mini Text-based game 1st/src/Room/RoomModel.java
+++ b/Mini Text-based game 1st/src/Room/RoomModel.java
@@ -50,7 +50,7 @@ public class RoomModel {
     @Override
     public String toString() {
         return String.format("%s%n%s%n%s%n%s",
-                getRoomNumber(), getRoomName(), getRoomConnections(), isVisited());
+                getRoomNumber(), getRoomName(), getRoomDescription(), isVisited());
     }
 
     public String iterateRoomConnection() {


### PR DESCRIPTION
The toString method accidentally outputted the data structure containing the room connections. It should have had the getRoomDescription method in that place because the getRoomConnections method is used in the iterateRoomConnection method.